### PR TITLE
feat: add tailwind to angulars postcss configs

### DIFF
--- a/libs/tailwind/src/constants/dependencies.ts
+++ b/libs/tailwind/src/constants/dependencies.ts
@@ -1,8 +1,4 @@
 export const DEPENDENCIES = [
-  'postcss',
   'tailwindcss',
-  'postcss-import',
-  'postcss-loader',
-  'autoprefixer',
   '@angular-builders/custom-webpack',
 ];

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -36,9 +36,7 @@ function patchWebpackPostcssPlugins({
         _postcssOptions.plugins.splice(insertIndex + position, 0, ...addPlugins);
         return _postcssOptions;
       };
-      return useLoader;
     }
-    return rule;
   }
 }
 

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,4 +1,8 @@
 function patchPostCSS(webpackConfig, tailwindConfig, components = false) {
+  if(!tailwindConfig){
+    console.error('Missing tailwind config :', tailwindConfig);
+    return;
+  }
   const pluginName = "autoprefixer";
   for (const rule of webpackConfig.module.rules) {
     if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude)) {

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,25 +1,56 @@
+function patchWebpackPostcssPlugins({
+  webpackConfig,
+  addPlugins = [],
+  pluginName = null,
+  append = false,
+  atIndex = null,
+  components = true,
+  global = true,
+}) {
+  const position = append ? 1 : 0;
+  webpackConfig.module.rules.map((rule) => {
+    if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude) || (!global && rule.include)) {
+      return rule;
+    }
+    rule.use.map((useLoader) => {
+      if (!(useLoader.options && useLoader.options.postcssOptions)) {
+        return useLoader;
+      }
+      const postcssOptions = useLoader.options.postcssOptions;
+      useLoader.options.postcssOptions = (loader) => {
+        const _postcssOptions = postcssOptions(loader);
+        const pluginIndex =
+          atIndex !== null
+            ? atIndex
+            : _postcssOptions.plugins.findIndex(
+                ({ postcssPlugin }) =>
+                  postcssPlugin && pluginName && postcssPlugin.toLowerCase() === pluginName.toLowerCase()
+              );
+        if (pluginName && pluginIndex === -1) {
+          console.warn(`${pluginName} not found in postcss plugins`);
+        }
+        const insertIndex =
+          pluginIndex >= 0
+            ? Math.min(Math.max(pluginIndex, 0), _postcssOptions.plugins.length)
+            : _postcssOptions.plugins.length;
+        _postcssOptions.plugins.splice(insertIndex + position, 0, ...addPlugins);
+        return _postcssOptions;
+      };
+      return useLoader;
+    });
+    return rule;
+  });
+}
+
 module.exports = (config) => {
   const isProd = config.mode === "production";
   const tailwindConfig = require("./tailwind.config.js")(isProd);
-
-  config.module.rules.map(rule=>{
-    if(rule.use && rule.use.length > 0){
-      rule.use.map(useLoader => {
-        if(useLoader.options && useLoader.options.postcssOptions){
-          const postcssOptions = useLoader.options.postcssOptions;
-          useLoader.options.postcssOptions = (loader) => {
-            const _postcssOptions = postcssOptions(loader);
-            const autoprefixerIndex = _postcssOptions.plugins.findIndex(v=>v.postcssPlugin === 'autoprefixer');
-            if(autoprefixerIndex){
-              _postcssOptions.plugins.splice(autoprefixerIndex, 0, require('tailwindcss')(tailwindConfig));
-            }
-            return _postcssOptions;
-          }
-        }
-        return useLoader;
-      })
-    }
-    return rule;
+  patchWebpackPostcssPlugins({
+    webpackConfig: config,
+    addPlugins: [require("tailwindcss")(tailwindConfig)],
+    pluginName: "autoprefixer",
+    // global: false,
+    // components: false,
   });
   return config;
 };

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,39 +1,24 @@
-function patchWebpackPostcssPlugins({
-  webpackConfig,
-  addPlugins = [],
-  pluginName = null,
-  append = false,
-  atIndex = null,
-  components = true,
-  global = true,
-}) {
-  const position = append ? 1 : 0;
-  for(const rule of webpackConfig.module.rules){
-    if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude) || (!global && rule.include)) {
+function patchPostCSS(webpackConfig, tailwindConfig, components = true) {
+  const pluginName = "autoprefixer";
+  for (const rule of webpackConfig.module.rules) {
+    if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude)) {
       continue;
     }
-    for(const useLoader of rule.use){
+    for (const useLoader of rule.use) {
       if (!(useLoader.options && useLoader.options.postcssOptions)) {
         continue;
       }
       const originPostcssOptions = useLoader.options.postcssOptions;
       useLoader.options.postcssOptions = (loader) => {
         const _postcssOptions = originPostcssOptions(loader);
-        const pluginIndex =
-          atIndex !== null
-            ? atIndex
-            : _postcssOptions.plugins.findIndex(
-                ({ postcssPlugin }) =>
-                  postcssPlugin && pluginName && postcssPlugin.toLowerCase() === pluginName.toLowerCase()
-              );
-        if (pluginName && pluginIndex === -1) {
-          console.warn(`${pluginName} not found in postcss plugins`);
+        const insertIndex = _postcssOptions.plugins.findIndex(
+          ({ postcssPlugin }) => postcssPlugin && postcssPlugin.toLowerCase() === pluginName
+        );
+        if (insertIndex !== -1) {
+          _postcssOptions.plugins.splice(insertIndex, 0, ["tailwindcss", tailwindConfig]);
+        } else {
+          console.error(`${pluginName} not found in postcss plugins`);
         }
-        const insertIndex =
-          pluginIndex >= 0
-            ? Math.min(Math.max(pluginIndex, 0), _postcssOptions.plugins.length)
-            : _postcssOptions.plugins.length;
-        _postcssOptions.plugins.splice(insertIndex + position, 0, ...addPlugins);
         return _postcssOptions;
       };
     }
@@ -43,14 +28,6 @@ function patchWebpackPostcssPlugins({
 module.exports = (config) => {
   const isProd = config.mode === "production";
   const tailwindConfig = require("./tailwind.config.js")(isProd);
-  patchWebpackPostcssPlugins({
-    webpackConfig: config,
-    addPlugins: [require("tailwindcss")(tailwindConfig)],
-    pluginName: "autoprefixer",
-    // global: false,
-    // components: false,
-    // atIndex: 2,
-    // append: false,
-  });
+  patchPostCSS(config, tailwindConfig);
   return config;
 };

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -8,17 +8,17 @@ function patchWebpackPostcssPlugins({
   global = true,
 }) {
   const position = append ? 1 : 0;
-  webpackConfig.module.rules.map((rule) => {
+  for(const rule of webpackConfig.module.rules){
     if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude) || (!global && rule.include)) {
-      return rule;
+      continue;
     }
-    rule.use.map((useLoader) => {
+    for(const useLoader of rule.use){
       if (!(useLoader.options && useLoader.options.postcssOptions)) {
-        return useLoader;
+        continue;
       }
-      const postcssOptions = useLoader.options.postcssOptions;
+      const originPostcssOptions = useLoader.options.postcssOptions;
       useLoader.options.postcssOptions = (loader) => {
-        const _postcssOptions = postcssOptions(loader);
+        const _postcssOptions = originPostcssOptions(loader);
         const pluginIndex =
           atIndex !== null
             ? atIndex
@@ -37,9 +37,9 @@ function patchWebpackPostcssPlugins({
         return _postcssOptions;
       };
       return useLoader;
-    });
+    }
     return rule;
-  });
+  }
 }
 
 module.exports = (config) => {
@@ -51,6 +51,8 @@ module.exports = (config) => {
     pluginName: "autoprefixer",
     // global: false,
     // components: false,
+    // atIndex: 2,
+    // append: false,
   });
   return config;
 };

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,29 +1,25 @@
-const webpackMerge = require('webpack-merge');
-
 module.exports = (config) => {
-  const merge = webpackMerge && webpackMerge.merge ? webpackMerge.merge : webpackMerge;
   const isProd = config.mode === "production";
   const tailwindConfig = require("./tailwind.config.js")(isProd);
 
-  return merge(config, {
-    module: {
-      rules: [
-        {
-          test: /\.<%= style %>$/,
-          loader: 'postcss-loader',
-          options: {
-            postcssOptions: {
-              ident: 'postcss',<% if(style !== 'css') {%>
-              syntax: 'postcss-<%= style %>',<% } %>
-              plugins: [
-                require('postcss-import'),
-                require('tailwindcss')(tailwindConfig),
-                require('autoprefixer'),
-              ]
+  config.module.rules.map(rule=>{
+    if(rule.use && rule.use.length > 0){
+      rule.use.map(useLoader => {
+        if(useLoader.options && useLoader.options.postcssOptions){
+          const postcssOptions = useLoader.options.postcssOptions;
+          useLoader.options.postcssOptions = (loader) => {
+            const _postcssOptions = postcssOptions(loader);
+            const autoprefixerIndex = _postcssOptions.plugins.findIndex(v=>v.postcssPlugin === 'autoprefixer');
+            if(autoprefixerIndex){
+              _postcssOptions.plugins.splice(autoprefixerIndex, 0, require('tailwindcss')(tailwindConfig));
             }
+            return _postcssOptions;
           }
         }
-      ]
+        return useLoader;
+      })
     }
+    return rule;
   });
+  return config;
 };

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,4 +1,4 @@
-function patchPostCSS(webpackConfig, tailwindConfig, components = true) {
+function patchPostCSS(webpackConfig, tailwindConfig, components = false) {
   const pluginName = "autoprefixer";
   for (const rule of webpackConfig.module.rules) {
     if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude)) {
@@ -28,6 +28,6 @@ function patchPostCSS(webpackConfig, tailwindConfig, components = true) {
 module.exports = (config) => {
   const isProd = config.mode === "production";
   const tailwindConfig = require("./tailwind.config.js")(isProd);
-  patchPostCSS(config, tailwindConfig);
+  patchPostCSS(config, tailwindConfig, <%= enableTailwindInComponentsStyles %>);
   return config;
 };

--- a/libs/tailwind/src/schematics/ng-add/ng-add.ts
+++ b/libs/tailwind/src/schematics/ng-add/ng-add.ts
@@ -73,7 +73,7 @@ function installDependencies(): Rule {
 
 function setupProject(options: TailwindSchematicsOptions): Rule {
   return chain([
-    addConfigFiles(),
+    addConfigFiles(options.enableTailwindInComponentsStyles),
     updateWorkspaceTargets(
       options.project,
       (updateWorkspace as unknown) as typeof updateNxWorkspace

--- a/libs/tailwind/src/schematics/ng-add/ng-add.ts
+++ b/libs/tailwind/src/schematics/ng-add/ng-add.ts
@@ -37,23 +37,17 @@ export default function (options: TailwindSchematicsOptions): Rule {
     }
 
     return chain([
-      addPackageJsonDependencies(options),
+      addPackageJsonDependencies(),
       installDependencies(),
       setupProject(options),
     ])(tree, context);
   };
 }
 
-function addPackageJsonDependencies(options: TailwindSchematicsOptions): Rule {
-  const deps = [...DEPENDENCIES];
-
-  if (options.style !== 'css') {
-    deps.push(`postcss-${options.style}`);
-  }
-
+function addPackageJsonDependencies(): Rule {
   return (tree, context) => {
     return Promise.all(
-      deps.map((dep) =>
+      [...DEPENDENCIES].map((dep) =>
         getLatestNodeVersion(dep).then(({ name, version }) => {
           context.logger.info(`✅️ Added ${name}@${version}`);
           const nodeDependency: NodeDependency = {
@@ -79,7 +73,7 @@ function installDependencies(): Rule {
 
 function setupProject(options: TailwindSchematicsOptions): Rule {
   return chain([
-    addConfigFiles(options.style),
+    addConfigFiles(),
     updateWorkspaceTargets(
       options.project,
       (updateWorkspace as unknown) as typeof updateNxWorkspace

--- a/libs/tailwind/src/schematics/ng-add/schema.json
+++ b/libs/tailwind/src/schematics/ng-add/schema.json
@@ -11,6 +11,12 @@
         "$source": "projectName"
       },
       "x-prompt": "What project would you like to use? (skip to use default project)"
+    },
+    "enableTailwindInComponentsStyles": {
+      "description": "Whether to use tailwind directives & functions in component styles?",
+      "type": "boolean",
+      "default": false,
+      "x-prompt": "Would you like to use tailwind directives & functions in component styles?"
     }
   }
 }

--- a/libs/tailwind/src/schematics/ng-add/schema.json
+++ b/libs/tailwind/src/schematics/ng-add/schema.json
@@ -11,34 +11,6 @@
         "$source": "projectName"
       },
       "x-prompt": "What project would you like to use? (skip to use default project)"
-    },
-    "style": {
-      "description": "The file extension or preprocessor to use for style files.",
-      "type": "string",
-      "default": "css",
-      "enum": [
-        "css",
-        "scss",
-        "sass"
-      ],
-      "x-prompt": {
-        "message": "Which stylesheet flavor would you like to use? (CSS, SCSS, SASS)",
-        "type": "list",
-        "items": [
-          {
-            "value": "css",
-            "label": "CSS"
-          },
-          {
-            "value": "scss",
-            "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]"
-          },
-          {
-            "value": "sass",
-            "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]"
-          }
-        ]
-      }
     }
   }
 }

--- a/libs/tailwind/src/schematics/ng-add/schema.json
+++ b/libs/tailwind/src/schematics/ng-add/schema.json
@@ -13,10 +13,10 @@
       "x-prompt": "What project would you like to use? (skip to use default project)"
     },
     "enableTailwindInComponentsStyles": {
-      "description": "Whether to use tailwind directives & functions in component styles?",
+      "description": "Whether to use tailwind directives & functions in component styles? (might increase build time)",
       "type": "boolean",
       "default": false,
-      "x-prompt": "Would you like to use tailwind directives & functions in component styles?"
+      "x-prompt": "Would you like to use tailwind directives & functions in component styles? (might increase build time)"
     }
   }
 }

--- a/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
+++ b/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
@@ -44,7 +44,7 @@ export default function (options: TailwindSchematicsOptions): Rule {
       return;
     }
 
-    const { projectName, appsDir, libsDir } = normalizeOptions(
+    const { enableTailwindInComponentsStyles, projectName, appsDir, libsDir } = normalizeOptions(
       options,
       tree,
       context
@@ -52,7 +52,7 @@ export default function (options: TailwindSchematicsOptions): Rule {
 
     return chain([
       addDependenciesToPackageJson(),
-      addConfigFiles(appsDir, libsDir),
+      addConfigFiles(enableTailwindInComponentsStyles, appsDir, libsDir),
       updateWorkspaceTargets(projectName, updateWorkspace),
       updateProjectRootStyles(projectName, getWorkspace, InsertChange),
     ])(tree, context);

--- a/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
+++ b/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
@@ -44,32 +44,26 @@ export default function (options: TailwindSchematicsOptions): Rule {
       return;
     }
 
-    const { projectName, style, appsDir, libsDir } = normalizeOptions(
+    const { projectName, appsDir, libsDir } = normalizeOptions(
       options,
       tree,
       context
     );
 
     return chain([
-      addDependenciesToPackageJson(style),
-      addConfigFiles(style, appsDir, libsDir),
+      addDependenciesToPackageJson(),
+      addConfigFiles(appsDir, libsDir),
       updateWorkspaceTargets(projectName, updateWorkspace),
       updateProjectRootStyles(projectName, getWorkspace, InsertChange),
     ])(tree, context);
   };
 }
 
-function addDependenciesToPackageJson(style: string): Rule {
-  const deps = [...DEPENDENCIES];
-
-  if (style !== 'css') {
-    deps.push(`postcss-${style}`);
-  }
-
+function addDependenciesToPackageJson(): Rule {
   return async (tree: Tree, ctx: SchematicContext) => {
     const devDeps = (
       await Promise.all(
-        deps.map((dep) =>
+        [...DEPENDENCIES].map((dep) =>
           getLatestNodeVersion(dep).then(({ name, version }) => {
             ctx.logger.info(`✅️ Added ${name}@${version}`);
             return { name, version };

--- a/libs/tailwind/src/schematics/nx-setup/schema.json
+++ b/libs/tailwind/src/schematics/nx-setup/schema.json
@@ -14,10 +14,10 @@
       "x-prompt": "What project would you like to use? (skip to use default project)"
     },
     "enableTailwindInComponentsStyles": {
-      "description": "Whether to use tailwind directives & functions in component styles?",
+      "description": "Whether to use tailwind directives & functions in component styles? (might increase build time)",
       "type": "boolean",
       "default": false,
-      "x-prompt": "Would you like to use tailwind directives & functions in component styles?"
+      "x-prompt": "Would you like to use tailwind directives & functions in component styles? (might increase build time)"
     }
   }
 }

--- a/libs/tailwind/src/schematics/nx-setup/schema.json
+++ b/libs/tailwind/src/schematics/nx-setup/schema.json
@@ -12,34 +12,6 @@
         "index": 0
       },
       "x-prompt": "What project would you like to use? (skip to use default project)"
-    },
-    "style": {
-      "description": "The file extension or preprocessor to use for style files.",
-      "type": "string",
-      "default": "css",
-      "enum": [
-        "css",
-        "scss",
-        "sass"
-      ],
-      "x-prompt": {
-        "message": "Which stylesheet flavor would you like to use? (CSS, SCSS, SASS)",
-        "type": "list",
-        "items": [
-          {
-            "value": "css",
-            "label": "CSS"
-          },
-          {
-            "value": "scss",
-            "label": "SCSS   [ https://sass-lang.com/documentation/syntax#scss                ]"
-          },
-          {
-            "value": "sass",
-            "label": "Sass   [ https://sass-lang.com/documentation/syntax#the-indented-syntax ]"
-          }
-        ]
-      }
     }
   }
 }

--- a/libs/tailwind/src/schematics/nx-setup/schema.json
+++ b/libs/tailwind/src/schematics/nx-setup/schema.json
@@ -12,6 +12,12 @@
         "index": 0
       },
       "x-prompt": "What project would you like to use? (skip to use default project)"
+    },
+    "enableTailwindInComponentsStyles": {
+      "description": "Whether to use tailwind directives & functions in component styles?",
+      "type": "boolean",
+      "default": false,
+      "x-prompt": "Would you like to use tailwind directives & functions in component styles?"
     }
   }
 }

--- a/libs/tailwind/src/schematics/schema.d.ts
+++ b/libs/tailwind/src/schematics/schema.d.ts
@@ -1,4 +1,3 @@
 export interface TailwindSchematicsOptions {
   project: string;
-  style: string;
 }

--- a/libs/tailwind/src/schematics/schema.d.ts
+++ b/libs/tailwind/src/schematics/schema.d.ts
@@ -1,3 +1,4 @@
 export interface TailwindSchematicsOptions {
   project: string;
+  enableTailwindInComponentsStyles: boolean;
 }

--- a/libs/tailwind/src/utils/add-config-files.ts
+++ b/libs/tailwind/src/utils/add-config-files.ts
@@ -10,12 +10,14 @@ import {
 import { isInJest } from './is-in-jest';
 
 export function addConfigFiles(
+  enableTailwindInComponentsStyles: boolean,
   appsDir?: string,
   libsDir?: string
 ): Rule {
   return mergeWith(
     apply(url(isInJest() ? '../files' : './files'), [
       applyTemplates({
+        enableTailwindInComponentsStyles,
         appsDir,
         libsDir,
       }),

--- a/libs/tailwind/src/utils/add-config-files.ts
+++ b/libs/tailwind/src/utils/add-config-files.ts
@@ -10,14 +10,12 @@ import {
 import { isInJest } from './is-in-jest';
 
 export function addConfigFiles(
-  style: string,
   appsDir?: string,
   libsDir?: string
 ): Rule {
   return mergeWith(
     apply(url(isInJest() ? '../files' : './files'), [
       applyTemplates({
-        style,
         appsDir,
         libsDir,
       }),


### PR DESCRIPTION
This PR:
- Adds tailwinds [directives & functions](https://tailwindcss.com/docs/functions-and-directives) support (e.g`@apply`).
- Fixes SCSS import issues
- adds LESS & Stylus support

closes #15, closes #24, closes #26

As angular >=11.0.5 have PostCSS 8 built-in support and instead of adding a new loader we can (and should) inject tailwind plugin in Angulars PostCSS config. Also as a result that we are adding a tailwind to all Angulars PostCSS configs - any style supported by angular will work with tailwinds `@apply`. You can see it in action here: https://github.com/vltansky/tailwind-ng11
I'm using tailwind in multiple files at the same time: `styles.less`, `app.component.css` and `styles.scss` (sass and stylus should work too)
But I don't have experience with schematics, I didn't succeed to run the `ng add` locally. 
Would be happy to get help with this
