### PR TITLE
feat: put patchPostCSS into package

### DIFF
--- a/libs/tailwind/src/index.ts
+++ b/libs/tailwind/src/index.ts
@@ -1,0 +1,30 @@
+export function patchPostCSS(webpackConfig, tailwindConfig, components = false) {
+  if(!tailwindConfig){
+    console.error('Missing tailwind config :', tailwindConfig);
+    return;
+  }
+  const pluginName = "autoprefixer";
+  for (const rule of webpackConfig.module.rules) {
+    if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude)) {
+      continue;
+    }
+    for (const useLoader of rule.use) {
+      if (!(useLoader.options && useLoader.options.postcssOptions)) {
+        continue;
+      }
+      const originPostcssOptions = useLoader.options.postcssOptions;
+      useLoader.options.postcssOptions = (loader) => {
+        const _postcssOptions = originPostcssOptions(loader);
+        const insertIndex = _postcssOptions.plugins.findIndex(
+          ({ postcssPlugin }) => postcssPlugin && postcssPlugin.toLowerCase() === pluginName
+        );
+        if (insertIndex !== -1) {
+          _postcssOptions.plugins.splice(insertIndex, 0, ["tailwindcss", tailwindConfig]);
+        } else {
+          console.error(`${pluginName} not found in postcss plugins`);
+        }
+        return _postcssOptions;
+      };
+    }
+  }
+}

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,33 +1,4 @@
-function patchPostCSS(webpackConfig, tailwindConfig, components = false) {
-  if(!tailwindConfig){
-    console.error('Missing tailwind config :', tailwindConfig);
-    return;
-  }
-  const pluginName = "autoprefixer";
-  for (const rule of webpackConfig.module.rules) {
-    if (!(rule.use && rule.use.length > 0) || (!components && rule.exclude)) {
-      continue;
-    }
-    for (const useLoader of rule.use) {
-      if (!(useLoader.options && useLoader.options.postcssOptions)) {
-        continue;
-      }
-      const originPostcssOptions = useLoader.options.postcssOptions;
-      useLoader.options.postcssOptions = (loader) => {
-        const _postcssOptions = originPostcssOptions(loader);
-        const insertIndex = _postcssOptions.plugins.findIndex(
-          ({ postcssPlugin }) => postcssPlugin && postcssPlugin.toLowerCase() === pluginName
-        );
-        if (insertIndex !== -1) {
-          _postcssOptions.plugins.splice(insertIndex, 0, ["tailwindcss", tailwindConfig]);
-        } else {
-          console.error(`${pluginName} not found in postcss plugins`);
-        }
-        return _postcssOptions;
-      };
-    }
-  }
-}
+import patchPostCSS from "@ngneat/tailwind";
 
 module.exports = (config) => {
   const isProd = config.mode === "production";


### PR DESCRIPTION
Move `patchPostCSS` function from `webpack.config.js` into package, so we could update the package according to if the function will need patches. The only problem is testing as `npx ng generate ./../tailwind/dist/libs/tailwind:ng-add` not adding `@ngneat/tailwind` to dependencies..