### PR TITLE
feat: add option to enable dark mode during setup

### DIFF
--- a/libs/tailwind/src/schematics/files/tailwind.config.js.template
+++ b/libs/tailwind/src/schematics/files/tailwind.config.js.template
@@ -8,7 +8,7 @@ module.exports = (isProd) => ({
         './<%= libsDir %>/**/*.{html,ts}',<% } %>
       ]
     },
-    darkMode: false, // or 'media' or 'class'
+    darkMode: <% if (darkMode !== 'none') {%>'<%= darkMode %>'<% } else { %>false<% } %>, // or 'media' or 'class'
     theme: {
       extend: {},
     },

--- a/libs/tailwind/src/schematics/ng-add/ng-add.ts
+++ b/libs/tailwind/src/schematics/ng-add/ng-add.ts
@@ -83,6 +83,7 @@ function setupProject(
   return chain([
     addConfigFiles(
       options.enableTailwindInComponentsStyles,
+      options.darkMode,
       undefined,
       undefined,
       projectSourceRoot

--- a/libs/tailwind/src/schematics/ng-add/schema.json
+++ b/libs/tailwind/src/schematics/ng-add/schema.json
@@ -12,6 +12,12 @@
       },
       "x-prompt": "What project would you like to use? (skip to use default project)"
     },
+    "darkMode": {
+      "description": "Whether to enable darkMode in tailwind.config.js",
+      "type": "string",
+      "enum": ["none", "class", "media"],
+      "default": "none"
+    },
     "enableTailwindInComponentsStyles": {
       "description": "Whether to use tailwind directives & functions in component styles? (might increase build time)",
       "type": "boolean",

--- a/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
+++ b/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
@@ -44,15 +44,22 @@ export default function (options: TailwindSchematicsOptions): Rule {
       return;
     }
 
-    const { enableTailwindInComponentsStyles, projectName, appsDir, libsDir } = normalizeOptions(
-      options,
-      tree,
-      context
-    );
+    const {
+      enableTailwindInComponentsStyles,
+      darkMode,
+      projectName,
+      appsDir,
+      libsDir,
+    } = normalizeOptions(options, tree, context);
 
     return chain([
       addDependenciesToPackageJson(),
-      addConfigFiles(enableTailwindInComponentsStyles, appsDir, libsDir),
+      addConfigFiles(
+        enableTailwindInComponentsStyles,
+        darkMode,
+        appsDir,
+        libsDir
+      ),
       updateWorkspaceTargets(projectName, updateWorkspace),
       updateProjectRootStyles(projectName, getWorkspace, InsertChange),
     ])(tree, context);
@@ -103,6 +110,7 @@ function normalizeOptions(
       .split(projectRootDir(ProjectType.Application) + '/')
       .pop(),
     projectRoot: project.data.root,
+    darkMode: options.darkMode || 'none',
     appsDir: appsDir(tree),
     libsDir: libsDir(tree),
   };

--- a/libs/tailwind/src/schematics/nx-setup/schema.json
+++ b/libs/tailwind/src/schematics/nx-setup/schema.json
@@ -13,6 +13,12 @@
       },
       "x-prompt": "What project would you like to use? (skip to use default project)"
     },
+    "darkMode": {
+      "description": "Whether to enable darkMode in tailwind.config.js",
+      "type": "string",
+      "enum": ["none", "class", "media"],
+      "default": "none"
+    },
     "enableTailwindInComponentsStyles": {
       "description": "Whether to use tailwind directives & functions in component styles? (might increase build time)",
       "type": "boolean",

--- a/libs/tailwind/src/schematics/schema.d.ts
+++ b/libs/tailwind/src/schematics/schema.d.ts
@@ -1,4 +1,5 @@
 export interface TailwindSchematicsOptions {
   project: string;
+  darkMode: 'none' | 'class' | 'media';
   enableTailwindInComponentsStyles: boolean;
 }

--- a/libs/tailwind/src/schematics/specs/schematics.spec.ts
+++ b/libs/tailwind/src/schematics/specs/schematics.spec.ts
@@ -147,6 +147,37 @@ Object.entries(schematicsTestOptions).forEach(([schematic, options]) => {
         .toPromise();
       expect(tree.exists('./tailwind.config.js')).toEqual(true);
       expect(tree.exists('./webpack.config.js')).toEqual(true);
+      expect(tree.readContent('./tailwind.config.js')).toContain(
+        `darkMode: false`
+      );
+      done();
+    });
+
+    it(`should add a tailwind config to with darkMode set to 'class'`, async (done) => {
+      const tree = await schematicRunner
+        .runSchematicAsync(
+          schematic,
+          { style: 'scss', project: 'foo', darkMode: 'class' },
+          appTree
+        )
+        .toPromise();
+      expect(tree.readContent('./tailwind.config.js')).toContain(
+        `darkMode: 'class'`
+      );
+      done();
+    });
+
+    it(`should add a tailwind config to with darkMode set to 'media'`, async (done) => {
+      const tree = await schematicRunner
+        .runSchematicAsync(
+          schematic,
+          { style: 'scss', project: 'foo', darkMode: 'media' },
+          appTree
+        )
+        .toPromise();
+      expect(tree.readContent('./tailwind.config.js')).toContain(
+        `darkMode: 'media'`
+      );
       done();
     });
   });

--- a/libs/tailwind/src/utils/add-config-files.ts
+++ b/libs/tailwind/src/utils/add-config-files.ts
@@ -11,6 +11,7 @@ import { isInJest } from './is-in-jest';
 
 export function addConfigFiles(
   enableTailwindInComponentsStyles: boolean,
+  darkMode: 'none' | 'class' | 'media',
   appsDir?: string,
   libsDir?: string,
   sourceRoot = 'src'
@@ -19,6 +20,7 @@ export function addConfigFiles(
     apply(url(isInJest() ? '../files' : './files'), [
       applyTemplates({
         enableTailwindInComponentsStyles,
+        darkMode,
         appsDir,
         libsDir,
         sourceRoot,


### PR DESCRIPTION
This PR adds support for adding Tailwind to an Angular app with dark mode set to `class` or `media` (and defaults to `none`). 