### PR TITLE
refactor: abstract out normalizeOptions

### DIFF
--- a/libs/tailwind/src/schematics/ng-add/ng-add.ts
+++ b/libs/tailwind/src/schematics/ng-add/ng-add.ts
@@ -42,17 +42,17 @@ export default function (options: TailwindSchematicsOptions): Rule {
     const projectSourceRoot = workspace.projects[options.project]?.sourceRoot;
 
     return chain([
-      addPackageJsonDependencies(),
+      addPackageJsonDependencies(DEPENDENCIES),
       installDependencies(),
       setupProject(options, projectSourceRoot),
     ])(tree, context);
   };
 }
 
-function addPackageJsonDependencies(): Rule {
+function addPackageJsonDependencies(dependencies: string[]): Rule {
   return (tree, context) => {
     return Promise.all(
-      [...DEPENDENCIES].map((dep) =>
+      dependencies.map((dep) =>
         getLatestNodeVersion(dep).then(({ name, version }) => {
           context.logger.info(`✅️ Added ${name}@${version}`);
           const nodeDependency: NodeDependency = {

--- a/libs/tailwind/src/schematics/ng-add/ng-add.ts
+++ b/libs/tailwind/src/schematics/ng-add/ng-add.ts
@@ -9,7 +9,6 @@ import type {
   updateWorkspace as updateNxWorkspace,
 } from '@nrwl/workspace';
 import { InsertChange } from '@schematics/angular/utility/change';
-import { getWorkspace as getWorkspaceConfig } from '@schematics/angular/utility/config';
 import {
   addPackageJsonDependency,
   NodeDependency,
@@ -19,8 +18,6 @@ import {
   getWorkspace,
   updateWorkspace,
 } from '@schematics/angular/utility/workspace';
-
-import { DEPENDENCIES } from '../../constants';
 import {
   addConfigFiles,
   getLatestNodeVersion,
@@ -28,7 +25,11 @@ import {
   updateProjectRootStyles,
   updateWorkspaceTargets,
 } from '../../utils';
-import type { TailwindSchematicsOptions } from '../schema';
+import { normalizeOptions } from '../../utils/normalize-options';
+import type {
+  NormalizedTailwindSchematicsOptions,
+  TailwindSchematicsOptions,
+} from '../schema';
 
 export default function (options: TailwindSchematicsOptions): Rule {
   return (tree, context) => {
@@ -37,14 +38,12 @@ export default function (options: TailwindSchematicsOptions): Rule {
       context.addTask(new RunSchematicTask('nx-setup', options));
       return tree;
     }
-
-    const workspace = getWorkspaceConfig(tree);
-    const projectSourceRoot = workspace.projects[options.project]?.sourceRoot;
+    const normalizedOptions = normalizeOptions(options, tree, context);
 
     return chain([
-      addPackageJsonDependencies(DEPENDENCIES),
+      addPackageJsonDependencies(normalizedOptions.dependencies),
       installDependencies(),
-      setupProject(options, projectSourceRoot),
+      setupProject(normalizedOptions),
     ])(tree, context);
   };
 }
@@ -76,18 +75,9 @@ function installDependencies(): Rule {
   };
 }
 
-function setupProject(
-  options: TailwindSchematicsOptions,
-  projectSourceRoot?: string
-): Rule {
+function setupProject(options: NormalizedTailwindSchematicsOptions): Rule {
   return chain([
-    addConfigFiles(
-      options.enableTailwindInComponentsStyles,
-      options.darkMode,
-      undefined,
-      undefined,
-      projectSourceRoot
-    ),
+    addConfigFiles(options),
     updateWorkspaceTargets(
       options.project,
       (updateWorkspace as unknown) as typeof updateNxWorkspace

--- a/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
+++ b/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
@@ -33,6 +33,7 @@ interface NormalizedTailwindSchematicsOptions
   projectDirectory: string;
   appsDir?: string;
   libsDir?: string;
+  dependencies?: string[];
 }
 
 export default function (options: TailwindSchematicsOptions): Rule {
@@ -50,10 +51,11 @@ export default function (options: TailwindSchematicsOptions): Rule {
       projectName,
       appsDir,
       libsDir,
+      dependencies,
     } = normalizeOptions(options, tree, context);
 
     return chain([
-      addDependenciesToPackageJson(),
+      addDependenciesToPackageJson(dependencies),
       addConfigFiles(
         enableTailwindInComponentsStyles,
         darkMode,
@@ -66,11 +68,11 @@ export default function (options: TailwindSchematicsOptions): Rule {
   };
 }
 
-function addDependenciesToPackageJson(): Rule {
+function addDependenciesToPackageJson(dependencies: string[]): Rule {
   return async (tree: Tree, ctx: SchematicContext) => {
     const devDeps = (
       await Promise.all(
-        [...DEPENDENCIES].map((dep) =>
+        dependencies.map((dep) =>
           getLatestNodeVersion(dep).then(({ name, version }) => {
             ctx.logger.info(`✅️ Added ${name}@${version}`);
             return { name, version };
@@ -102,6 +104,8 @@ function normalizeOptions(
     throw new Error(msg);
   }
 
+  const dependencies = [...DEPENDENCIES];
+
   return {
     ...options,
     project: project.name,
@@ -113,6 +117,7 @@ function normalizeOptions(
     darkMode: options.darkMode || 'none',
     appsDir: appsDir(tree),
     libsDir: libsDir(tree),
+    dependencies,
   };
 }
 

--- a/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
+++ b/libs/tailwind/src/schematics/nx-setup/nx-setup.ts
@@ -6,17 +6,10 @@ import {
 } from '@angular-devkit/schematics';
 import {
   addDepsToPackageJson,
-  getProjectGraphFromHost,
   getWorkspace,
   InsertChange,
-  ProjectGraph,
-  ProjectGraphNode,
-  projectRootDir,
-  ProjectType,
   updateWorkspace,
 } from '@nrwl/workspace';
-import { appsDir, libsDir } from '@nrwl/workspace/src/utils/ast-utils';
-import { DEPENDENCIES } from '../../constants';
 import {
   addConfigFiles,
   getLatestNodeVersion,
@@ -24,17 +17,8 @@ import {
   updateProjectRootStyles,
   updateWorkspaceTargets,
 } from '../../utils';
+import { normalizeOptions } from '../../utils/normalize-options';
 import type { TailwindSchematicsOptions } from '../schema';
-
-interface NormalizedTailwindSchematicsOptions
-  extends TailwindSchematicsOptions {
-  projectName: string;
-  projectRoot: string;
-  projectDirectory: string;
-  appsDir?: string;
-  libsDir?: string;
-  dependencies?: string[];
-}
 
 export default function (options: TailwindSchematicsOptions): Rule {
   return (tree, context) => {
@@ -45,25 +29,17 @@ export default function (options: TailwindSchematicsOptions): Rule {
       return;
     }
 
-    const {
-      enableTailwindInComponentsStyles,
-      darkMode,
-      projectName,
-      appsDir,
-      libsDir,
-      dependencies,
-    } = normalizeOptions(options, tree, context);
+    const normalizedOptions = normalizeOptions(options, tree, context);
 
     return chain([
-      addDependenciesToPackageJson(dependencies),
-      addConfigFiles(
-        enableTailwindInComponentsStyles,
-        darkMode,
-        appsDir,
-        libsDir
+      addDependenciesToPackageJson(normalizedOptions.dependencies),
+      addConfigFiles(normalizedOptions),
+      updateWorkspaceTargets(normalizedOptions.projectName, updateWorkspace),
+      updateProjectRootStyles(
+        normalizedOptions.projectName,
+        getWorkspace,
+        InsertChange
       ),
-      updateWorkspaceTargets(projectName, updateWorkspace),
-      updateProjectRootStyles(projectName, getWorkspace, InsertChange),
     ])(tree, context);
   };
 }
@@ -86,52 +62,4 @@ function addDependenciesToPackageJson(dependencies: string[]): Rule {
 
     return addDepsToPackageJson({}, devDeps)(tree, ctx) as Rule;
   };
-}
-
-function normalizeOptions(
-  options: TailwindSchematicsOptions,
-  tree: Tree,
-  context: SchematicContext
-): NormalizedTailwindSchematicsOptions {
-  const project = getDefaultProjectFromGraph(
-    getProjectGraphFromHost(tree),
-    options.project
-  );
-
-  if (project == null) {
-    const msg = `Cannot find any Angular project in the current workspace.`;
-    context.logger.fatal(msg);
-    throw new Error(msg);
-  }
-
-  const dependencies = [...DEPENDENCIES];
-
-  return {
-    ...options,
-    project: project.name,
-    projectName: project.name,
-    projectDirectory: project.data.root
-      .split(projectRootDir(ProjectType.Application) + '/')
-      .pop(),
-    projectRoot: project.data.root,
-    darkMode: options.darkMode || 'none',
-    appsDir: appsDir(tree),
-    libsDir: libsDir(tree),
-    dependencies,
-  };
-}
-
-function getDefaultProjectFromGraph(
-  graph: ProjectGraph,
-  projectName?: string
-): ProjectGraphNode {
-  if (projectName) return graph.nodes[projectName];
-  return Object.values(graph.nodes).find(
-    (node) =>
-      node.type === 'app' &&
-      node.data.projectType === ProjectType.Application &&
-      Object.values(node.data.architect).some((target) =>
-        target.builder.includes('angular')
-      )
-  );
 }

--- a/libs/tailwind/src/schematics/schema.d.ts
+++ b/libs/tailwind/src/schematics/schema.d.ts
@@ -1,5 +1,18 @@
+export type TailwindDarkMode = 'none' | 'class' | 'media';
+
 export interface TailwindSchematicsOptions {
   project: string;
-  darkMode: 'none' | 'class' | 'media';
+  darkMode: TailwindDarkMode;
   enableTailwindInComponentsStyles: boolean;
+}
+
+export interface NormalizedTailwindSchematicsOptions
+  extends TailwindSchematicsOptions {
+  projectName?: string;
+  projectRoot?: string;
+  sourceRoot?: string;
+  projectDirectory?: string;
+  appsDir?: string;
+  libsDir?: string;
+  dependencies?: string[];
 }

--- a/libs/tailwind/src/utils/add-config-files.ts
+++ b/libs/tailwind/src/utils/add-config-files.ts
@@ -7,15 +7,16 @@ import {
   Rule,
   url,
 } from '@angular-devkit/schematics';
+import { NormalizedTailwindSchematicsOptions } from '../schematics/schema';
 import { isInJest } from './is-in-jest';
 
-export function addConfigFiles(
-  enableTailwindInComponentsStyles: boolean,
-  darkMode: 'none' | 'class' | 'media',
-  appsDir?: string,
-  libsDir?: string,
-  sourceRoot = 'src'
-): Rule {
+export function addConfigFiles({
+  enableTailwindInComponentsStyles,
+  darkMode,
+  appsDir,
+  libsDir,
+  sourceRoot = 'src',
+}: NormalizedTailwindSchematicsOptions): Rule {
   return mergeWith(
     apply(url(isInJest() ? '../files' : './files'), [
       applyTemplates({

--- a/libs/tailwind/src/utils/normalize-options.ts
+++ b/libs/tailwind/src/utils/normalize-options.ts
@@ -1,0 +1,76 @@
+import { SchematicContext, Tree } from '@angular-devkit/schematics';
+import {
+  getProjectGraphFromHost,
+  ProjectGraph,
+  ProjectGraphNode,
+  projectRootDir,
+  ProjectType,
+} from '@nrwl/workspace';
+import { appsDir, libsDir } from '@nrwl/workspace/src/utils/ast-utils';
+import { getWorkspace as getWorkspaceConfig } from '@schematics/angular/utility/config';
+import { DEPENDENCIES } from '../constants';
+import {
+  NormalizedTailwindSchematicsOptions,
+  TailwindSchematicsOptions,
+} from '../schematics/schema';
+import { isNx } from './is-nx';
+
+export function getDefaultProjectFromGraph(
+  graph: ProjectGraph,
+  projectName?: string
+): ProjectGraphNode {
+  if (projectName) return graph.nodes[projectName];
+  return Object.values(graph.nodes).find(
+    (node) =>
+      node.type === 'app' &&
+      node.data.projectType === ProjectType.Application &&
+      Object.values(node.data.architect).some((target) =>
+        target.builder.includes('angular')
+      )
+  );
+}
+
+export function normalizeOptions(
+  options: TailwindSchematicsOptions,
+  tree: Tree,
+  context: SchematicContext
+): NormalizedTailwindSchematicsOptions {
+  const dependencies = [...DEPENDENCIES];
+  const darkMode = options.darkMode || 'none';
+  if (isNx(tree)) {
+    const project = getDefaultProjectFromGraph(
+      getProjectGraphFromHost(tree),
+      options.project
+    );
+
+    if (project == null) {
+      const msg = `Cannot find any Angular project in the current workspace.`;
+      context.logger.fatal(msg);
+      throw new Error(msg);
+    }
+
+    return {
+      ...options,
+      project: project.name,
+      projectName: project.name,
+      projectDirectory: project.data.root
+        .split(projectRootDir(ProjectType.Application) + '/')
+        .pop(),
+      projectRoot: project.data.root,
+      appsDir: appsDir(tree),
+      libsDir: libsDir(tree),
+      darkMode,
+      dependencies,
+    };
+  }
+
+  const workspace = getWorkspaceConfig(tree);
+  const sourceRoot = workspace.projects[options.project]?.sourceRoot;
+
+  return {
+    ...options,
+    darkMode,
+    dependencies,
+    sourceRoot,
+  };
+}


### PR DESCRIPTION
As discussed yesterday, this PR abstracts the normalizeOptions so it's shared between `ng-add` and `nx-setup`.