### PR TITLE
fix: tailwindcss-intellisense support

### DIFF
--- a/libs/tailwind/src/patch-post-css.ts
+++ b/libs/tailwind/src/patch-post-css.ts
@@ -9,6 +9,9 @@ export function patchPostCSS(
     console.error('Missing tailwind config :', tailwindConfig);
     return;
   }
+  if(tailwindConfig.purge){
+    tailwindConfig.purge.enabled = webpackConfig.mode === "production";
+  }
   const pluginName = 'autoprefixer';
   for (const rule of webpackConfig.module.rules) {
     const ruleSetUseItems = rule.use as RuleSetUseItem[];

--- a/libs/tailwind/src/schematics/files/tailwind.config.js.template
+++ b/libs/tailwind/src/schematics/files/tailwind.config.js.template
@@ -1,4 +1,4 @@
-module.exports = (isProd) => ({
+module.exports = {
     prefix: '',
     purge: {
       enabled: isProd,
@@ -16,4 +16,4 @@ module.exports = (isProd) => ({
       extend: {},
     },
     plugins: [],
-});
+};

--- a/libs/tailwind/src/schematics/files/tailwind.config.js.template
+++ b/libs/tailwind/src/schematics/files/tailwind.config.js.template
@@ -1,7 +1,6 @@
 module.exports = {
     prefix: '',
     purge: {
-      enabled: isProd,
       content: [<% if (appsDir) {%>
         './<%= appsDir %>/**/*.{html,ts}',<% } else {%>
         './<%= sourceRoot %>/**/*.{html,ts}',<% } %><% if (libsDir) {%>

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,8 +1,7 @@
 const { patchPostCSS } = require("@ngneat/tailwind");
 
 module.exports = (config) => {
-  const isProd = config.mode === "production";
-  const tailwindConfig = require("./tailwind.config.js")(isProd);
+  const tailwindConfig = require("./tailwind.config.js");
   patchPostCSS(config, tailwindConfig<% if (enableTailwindInComponentsStyles) { %>, true);<% } else { %>);<% } %>
   return config;
 };


### PR DESCRIPTION
[Tailwindcss intellisense plugin](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) wont work with tailwind config that exports function.
This PR fixes it.
e.g you can try to add colors or setting `suffix` and see that the plugin won't detect your changes.