### PR TITLE
fix: change schema so plugins accepts a comma-separated string

### DIFF
--- a/libs/tailwind/src/schematics/ng-add/schema.json
+++ b/libs/tailwind/src/schematics/ng-add/schema.json
@@ -26,14 +26,22 @@
       "x-prompt": "Would you like to use tailwind directives & functions in component styles? (might increase build time)"
     },
     "plugins": {
-      "description": "What @tailwindcss plugins you want to enable in tailwind.config.js",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "enum": ["aspect-ratio", "forms", "line-clamp", "typography"],
-        "type": "string"
-      },
-      "x-prompt": "What @tailwindcss plugins do you want to enable?"
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "What @tailwindcss plugins you want to enable in tailwind.config.js"
+        },
+        {
+          "description": "What @tailwindcss plugins you want to enable in tailwind.config.js",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["aspect-ratio", "forms", "line-clamp", "typography"],
+            "type": "string"
+          },
+          "x-prompt": "What @tailwindcss plugins do you want to enable?"
+        }
+      ]
     }
   }
 }

--- a/libs/tailwind/src/schematics/nx-setup/schema.json
+++ b/libs/tailwind/src/schematics/nx-setup/schema.json
@@ -27,14 +27,22 @@
       "x-prompt": "Would you like to use tailwind directives & functions in component styles? (might increase build time)"
     },
     "plugins": {
-      "description": "What @tailwindcss plugins you want to enable in tailwind.config.js",
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "enum": ["aspect-ratio", "forms", "line-clamp", "typography"],
-        "type": "string"
-      },
-      "x-prompt": "What @tailwindcss plugins do you want to enable?"
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "What @tailwindcss plugins you want to enable in tailwind.config.js"
+        },
+        {
+          "description": "What @tailwindcss plugins you want to enable in tailwind.config.js",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "enum": ["aspect-ratio", "forms", "line-clamp", "typography"],
+            "type": "string"
+          },
+          "x-prompt": "What @tailwindcss plugins do you want to enable?"
+        }
+      ]
     }
   }
 }

--- a/libs/tailwind/src/schematics/schema.d.ts
+++ b/libs/tailwind/src/schematics/schema.d.ts
@@ -4,7 +4,7 @@ export interface TailwindSchematicsOptions {
   project: string;
   darkMode: TailwindDarkMode;
   enableTailwindInComponentsStyles: boolean;
-  plugins: string[];
+  plugins: string | string[];
 }
 
 export interface NormalizedTailwindSchematicsOptions

--- a/libs/tailwind/src/utils/get-dependencies.ts
+++ b/libs/tailwind/src/utils/get-dependencies.ts
@@ -1,9 +1,10 @@
 import { DEPENDENCIES } from '../constants';
 
 export function getDependencies(
-  plugins: string[] = []
+  plugins: string | string[] = []
 ): { dependencies: string[]; plugins: string[] } {
-  const pluginPackages = plugins?.map((plugin) => `@tailwindcss/${plugin}`);
+  const pluginArray = Array.isArray(plugins) ? plugins : plugins.split(',');
+  const pluginPackages = pluginArray?.map((plugin) => `@tailwindcss/${plugin}`);
 
   return {
     dependencies: [...DEPENDENCIES, ...pluginPackages],


### PR DESCRIPTION
With this change, the `--plugins` parameter accepts a string as an input, and in the place where we handle it, we `.split(',')` the string.

```
$ ng add @ngneat/tailwind --darkMode class --plugins 'forms,typography' --enable-tailwind-in-components-styles
Skipping installation: Package already installed
    ✅️ Added @tailwindcss/typography@0.3.1
    ✅️ Added @tailwindcss/forms@0.2.1
    ✅️ Added postcss@8.2.4
    ✅️ Added tailwindcss@2.0.2
    ✅️ Added @angular-builders/custom-webpack@11.0.0
    ✅️ Installed dependencies
CREATE tailwind.config.js (324 bytes)
CREATE webpack.config.js (210 bytes)
UPDATE package.json (1383 bytes)
UPDATE angular.json (3900 bytes)
UPDATE src/styles.css (175 bytes)
UPDATE src/index.html (314 bytes)
✔ Packages installed successfully.
```

Without params it will still prompt:

```
$ ng add @ngneat/tailwind --darkMode class  --enable-tailwind-in-components-styles
Installing packages for tooling via yarn.
Installed packages for tooling via yarn.
? What @tailwindcss plugins do you want to enable? (Press <space> to select, <a> to toggle all, <i> to invert selection)
❯◯ aspect-ratio
 ◯ forms
 ◯ line-clamp
 ◯ typography
```