### PR TITLE
fix(tailwind.config.js.template): fix for syntax error in tailwind config template

### DIFF
--- a/libs/tailwind/src/schematics/files/tailwind.config.js.template
+++ b/libs/tailwind/src/schematics/files/tailwind.config.js.template
@@ -15,4 +15,4 @@ module.exports = {
       extend: {},
     },
     plugins: [<%= plugins %>],
-});
+};


### PR DESCRIPTION
[fix #44](https://github.com/ngneat/tailwind/issues/44)

Removed unnecessary `)` at the end of the `tailwind.config.js.template` file