### PR TITLE
chore: remove postcss8 dependency

### DIFF
--- a/libs/tailwind/src/constants/dependencies.ts
+++ b/libs/tailwind/src/constants/dependencies.ts
@@ -1,5 +1,4 @@
 export const DEPENDENCIES = [
   'tailwindcss',
-  'postcss', // TODO: to remove when @angular-devkit uses PostCSS8
   '@angular-builders/custom-webpack',
 ];


### PR DESCRIPTION
Probably when angular `11.1.0` will be released.
As for `11.0.7` webpack still uses PostCSS 7 under the hood.