### PR TITLE
refactor: move tailwind.config import

### DIFF
--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,7 +1,7 @@
 const { patchPostCSS } = require("@ngneat/tailwind");
+const tailwindConfig = require("./tailwind.config.js");
 
 module.exports = (config) => {
-  const tailwindConfig = require("./tailwind.config.js");
   patchPostCSS(config, tailwindConfig<% if (enableTailwindInComponentsStyles) { %>, true);<% } else { %>);<% } %>
   return config;
 };


### PR DESCRIPTION
As we are just importing tailwind config, without passing a `isProd` variable anymore, there is no sense to keep it inside a function.
This PR just move the import to the head.