### PR TITLE
feat: simlify patchPostCSS

### DIFF
--- a/libs/tailwind/src/patch-post-css.ts
+++ b/libs/tailwind/src/patch-post-css.ts
@@ -1,4 +1,5 @@
 import type { Configuration, RuleSetLoader, RuleSetUseItem } from 'webpack';
+import * as path from 'path';
 
 export function patchPostCSS(
   webpackConfig: Configuration,
@@ -54,4 +55,16 @@ export function patchPostCSS(
       };
     }
   }
+}
+
+export function addTailwindCSS(
+  webpackConfig: Configuration,
+  { tailwindConfig = null, enableInComponentsStyles = false } = {}
+) {
+  if(!tailwindConfig){
+    try{
+      tailwindConfig = require(path.join(webpackConfig.resolve.roots[0],'tailwind.config.js'))
+    }catch(err){}
+  }
+  return patchPostCSS(webpackConfig, tailwindConfig, enableInComponentsStyles);
 }

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,7 +1,6 @@
-const { patchPostCSS } = require("@ngneat/tailwind");
-const tailwindConfig = require("./tailwind.config.js");
+const { addTailwindCSS } = require("@ngneat/tailwind");
 
 module.exports = (config) => {
-  patchPostCSS(config, tailwindConfig<% if (enableTailwindInComponentsStyles) { %>, true);<% } else { %>);<% } %>
+  addTailwindCSS(config<% if (enableTailwindInComponentsStyles) { %>, { enableInComponentsStyles: true });<% } else { %>);<% } %>
   return config;
 };


### PR DESCRIPTION
I thought that we don't have to force users to pass tailwind config, as `tailwind.config.js` probably will be the same path always. So we can require it by default (of course with optional to provide another config).

according to tailwind docs https://tailwindcss.com/docs/configuration:
> By default, Tailwind will look for an optional tailwind.config.js file at the root of your project where you can define any customizations.

I created a new function called `addTailwindCSS()` alongside with `patchPostCSS()` so it will be supported. 
Also, I moved `enableInComponentsStyles` into the params object, so it will be easier to maintain parameters in the future.


I used `webpackConfig.resolve.roots[0]` to find project root. Maybe there is a better way?

