### PR TITLE
refactor: rename patchPostCSS to addTailwindCSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,14 +55,14 @@
 ### Bug Fixes
 
 * add sourceRoot in webpack config template ([92bb009](https://github.com/ngneat/tailwind/commit/92bb0099492f68afc984dd1a93dfb3bb91a78a21))
-* move patchPostCss to separate file and use webpack types ([028f94e](https://github.com/ngneat/tailwind/commit/028f94e79ff0357858f2cf8fccc2791432d9ce33))
+* move addTailwindCSS to separate file and use webpack types ([028f94e](https://github.com/ngneat/tailwind/commit/028f94e79ff0357858f2cf8fccc2791432d9ce33))
 * use require instead of import syntax in webpack config template ([40dbb90](https://github.com/ngneat/tailwind/commit/40dbb90161f3f701af2bf8b57cb4a803e4d89b3c))
 
 
 ### Features
 
 * add option to enable dark mode during setup ([#34](https://github.com/ngneat/tailwind/issues/34)) ([9e442e5](https://github.com/ngneat/tailwind/commit/9e442e56360519985df36842826535693946cb8e))
-* put patchPostCSS into package ([#33](https://github.com/ngneat/tailwind/issues/33)) ([2bdc57a](https://github.com/ngneat/tailwind/commit/2bdc57ae42ae44b18f734c65cf0687ee6c93e3af))
+* put addTailwindCSS into package ([#33](https://github.com/ngneat/tailwind/issues/33)) ([2bdc57a](https://github.com/ngneat/tailwind/commit/2bdc57ae42ae44b18f734c65cf0687ee6c93e3af))
 
 # [5.0.0](https://github.com/ngneat/tailwind/compare/v3.0.7...v5.0.0) (2020-12-28)
 

--- a/README.md
+++ b/README.md
@@ -44,20 +44,20 @@ nx generate @ngneat/tailwind:nx-setup
 If your projects are already using a custom **Webpack** builder with a custom `webpack.config`, follow these steps to add **TailwindCSS** to your project
 
 - `npm i -D @ngneat/tailwind postcss` (or `yarn add -D @ngneat/tailwind postcss`)
-- Import `patchPostCSS` from `@ngneat/tailwind` in your `webpack.config`
+- Import `addTailwindCSS` from `@ngneat/tailwind` in your `webpack.config`
 - Import your **TailwindCSS** config in your `webpack.config`
-- Before you return or modify the original Webpack config, call `patchPostCSS` with the following parameters:
+- Before you return or modify the original Webpack config, call `addTailwindCSS` with the following parameters:
   - `webpackConfig`: the Webpack config
   - `tailwindConfig`: the TailwindCSS config that you import
   - `components?`: this flag will enable using TailwindCSS directives in components' stylesheets. Default to `false` because turning it on might impact your build time
 
 ```js
 // example
-const { patchPostCSS } = require('@ngneat/tailwind');
+const { addTailwindCSS } = require('@ngneat/tailwind');
 const tailwindConfig = require('relative/path/to/tailwind.config');
 
 module.exports = (config) => {
-  patchPostCSS(config, tailwindConfig, true);
+  addTailwindCSS(config, tailwindConfig, true);
   return config;
 }
 ```

--- a/libs/tailwind/README.md
+++ b/libs/tailwind/README.md
@@ -44,20 +44,20 @@ nx generate @ngneat/tailwind:nx-setup
 If your projects are already using a custom **Webpack** builder with a custom `webpack.config`, follow these steps to add **TailwindCSS** to your project
 
 - `npm i -D @ngneat/tailwind postcss` (or `yarn add -D @ngneat/tailwind postcss`)
-- Import `patchPostCSS` from `@ngneat/tailwind` in your `webpack.config`
+- Import `addTailwindCSS` from `@ngneat/tailwind` in your `webpack.config`
 - Import your **TailwindCSS** config in your `webpack.config`
-- Before you return or modify the original Webpack config, call `patchPostCSS` with the following parameters:
+- Before you return or modify the original Webpack config, call `addTailwindCSS` with the following parameters:
   - `webpackConfig`: the Webpack config
   - `tailwindConfig`: the TailwindCSS config that you import
   - `components?`: this flag will enable using TailwindCSS directives in components' stylesheets. Default to `false` because turning it on might impact your build time
 
 ```js
 // example
-const { patchPostCSS } = require('@ngneat/tailwind');
+const { addTailwindCSS } = require('@ngneat/tailwind');
 const tailwindConfig = require('relative/path/to/tailwind.config');
 
 module.exports = (config) => {
-  patchPostCSS(config, tailwindConfig, true);
+  addTailwindCSS(config, tailwindConfig, true);
   return config;
 }
 ```

--- a/libs/tailwind/src/patch-post-css.ts
+++ b/libs/tailwind/src/patch-post-css.ts
@@ -1,6 +1,6 @@
 import type { Configuration, RuleSetLoader, RuleSetUseItem } from 'webpack';
 
-export function patchPostCSS(
+export function addTailwindCSS(
   webpackConfig: Configuration,
   tailwindConfig,
   components = false
@@ -54,4 +54,12 @@ export function patchPostCSS(
       };
     }
   }
+}
+
+export function patchPostCSS(
+  webpackConfig: Configuration,
+  tailwindConfig,
+  components = false
+) {
+  return addTailwindCSS(webpackConfig, tailwindConfig, components);
 }

--- a/libs/tailwind/src/schematics/files/webpack.config.js.template
+++ b/libs/tailwind/src/schematics/files/webpack.config.js.template
@@ -1,7 +1,7 @@
-const { patchPostCSS } = require("@ngneat/tailwind");
+const { addTailwindCSS } = require("@ngneat/tailwind");
 const tailwindConfig = require("./tailwind.config.js");
 
 module.exports = (config) => {
-  patchPostCSS(config, tailwindConfig<% if (enableTailwindInComponentsStyles) { %>, true);<% } else { %>);<% } %>
+  addTailwindCSS(config, tailwindConfig<% if (enableTailwindInComponentsStyles) { %>, true);<% } else { %>);<% } %>
   return config;
 };


### PR DESCRIPTION
- rename patchPostCSS to addTailwindCSS
- patchPostCSS function is still there to support older versions, redirecting to addTailwindCSS function

Would we want to change parameters to options object?
from
`addTailwindCSS(webpackConfig: Configuration, tailwindConfig, components = false)`
to
```js
export interface IaddTailwindCSS{
  webpackConfig: Configuration,
  tailwindConfig: any,
  patchComponentsStyles?: boolean,
}


export interface 
addTailwindCSS({webpackConfig, tailwindConfig, patchInComponents = false}: IaddTailwindCSS)
```

so it will be easier to maintain it in the future (add, remove parameters)?
