### PR TITLE
chore: add postcss-ng-tailwind-in-components as dependency

### DIFF
--- a/libs/tailwind/package.json
+++ b/libs/tailwind/package.json
@@ -13,6 +13,9 @@
     "cli",
     "schematics"
   ],
+  "dependencies": {
+    "postcss-ng-tailwind-in-components": "^0.0.3"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ngneat/tailwind.git"

--- a/libs/tailwind/src/constants/dependencies.ts
+++ b/libs/tailwind/src/constants/dependencies.ts
@@ -1,5 +1,4 @@
 export const DEPENDENCIES = [
   'tailwindcss',
   '@angular-builders/custom-webpack',
-  'postcss-ng-tailwind-in-components',
 ];


### PR DESCRIPTION
https://github.com/ngneat/tailwind/issues/66#issuecomment-770902257

1. It's under the hood behavior of ngneat tailwind, I think including it as direct dependency is more correct behaivor.
2. We can control the version of the plugin behind the plugin while adding it to clients deps - is out of our control
3. Installing to an existing project with custom webpack without ng add will need to install postcss plugin too (right now not covered in readme)