### PR TITLE
fix: wrap getPackageManager with try catch for older versions

### DIFF
--- a/libs/tailwind/src/schematics/ng-add/ng-add.ts
+++ b/libs/tailwind/src/schematics/ng-add/ng-add.ts
@@ -49,12 +49,14 @@ export default function (options: TailwindSchematicsOptions): Rule {
     );
 
     if (!isTailwindSupported) {
-      const tailwindPkg = '@ngneat/tailwind';
-      const tailwindDep = getPackageJsonDependency(tree, tailwindPkg);
+      try{
+        const tailwindPkg = '@ngneat/tailwind';
+        const tailwindDep = getPackageJsonDependency(tree, tailwindPkg);
 
-      if (tailwindDep != null) {
-        execSync(`${getPackageManager(tree.root.path)} rm ${tailwindPkg}`);
-      }
+        if (tailwindDep != null) {
+          execSync(`${getPackageManager(tree.root.path)} rm ${tailwindPkg}`);
+        }
+      }catch(err){}
       context.logger.info(`
 Detected AngularCLI version is ${cliVersion} which does not support TailwindCSS natively.
 Please run "ng add @ngneat/tailwind@6" for Custom Webpack support.


### PR DESCRIPTION
closes #90 

Angular 11.2:

Now:
```
$ ng add @ngneat/tailwind
Your global Angular CLI version (11.2.7) is greater than your local version (11.1.4). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
Skipping installation: Package already installed
? Would you like to enable Tailwind JIT (preview feature)? No
? Would you like to enable dark mode? none
? What @tailwindcss plugins do you want to enable? 
'[object' is not recognized as an internal or external command,
operable program or batch file.
Command failed: [object Promise] rm @ngneat/tailwind
'[object' is not recognized as an internal or external command,
operable program or batch file.
```

Fix to:

```
$ ng add @ngneat/tailwind
Your global Angular CLI version (11.2.7) is greater than your local version (11.1.4). The local Angular CLI version is used.

To disable this warning use "ng config -g cli.warnings.versionMismatch false".
Skipping installation: Package already installed
? Would you like to enable Tailwind JIT (preview feature)? No
? Would you like to enable dark mode? none
? What @tailwindcss plugins do you want to enable? 
'[object' is not recognized as an internal or external command,
operable program or batch file.

    Detected AngularCLI version is 11.1.4 which does not support TailwindCSS natively.
    Please run "ng add @ngneat/tailwind@6" for Custom Webpack support.

Nothing to be done.
```