### PR TITLE
feat: remove setting TAILWIND_MODE env variable

### DIFF
--- a/libs/tailwind/src/schematics/files/tailwind.config.js.template
+++ b/libs/tailwind/src/schematics/files/tailwind.config.js.template
@@ -1,6 +1,4 @@
-const { guessProductionMode } = require("@ngneat/tailwind");<% if (enableJit) {%>
-
-process.env.TAILWIND_MODE = guessProductionMode() ? 'build' : 'watch';<% } %>
+const { guessProductionMode } = require("@ngneat/tailwind");
 
 module.exports = {
     prefix: '',<% if (enableJit) {%>


### PR DESCRIPTION
As Angular CLI 11.2.10 now sets `TAILWIND_MODE` we don't need to set it anymore.